### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,71 +1,71 @@
 {
-    "name": "generator-swift",
-    "version": "0.0.13",
-    "description": "Yeoman generator for opensource swift projects",
-    "license": "Apache-2.0",
-    "main": "app/index.js",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/jmuelbert/generator-swift.git"
-    },
-    "contributors": [
-        "Jürgen Mülbert < > (https://github.com/jmuelbert)"
-    ],
-    "engines": {
-        "node": ">=0.10.0"
-    },
-    "keywords": [
-        "yeoman-generator",
-        "swift"
-    ],
-    "files": [
-        "app"
-    ],
-    "dependencies": {
-        "chai": "^3.5.0",
-        "chalk": "^1.1.3",
-        "findup-sync": "^0.4.2",
-        "nconf": "^0.8.4",
-        "vs_projectname": "^1.0.2",
-        "yeoman-generator": "^0.22.5",
-        "yosay": "^1.1.0",
-        "node-uuid": "^1.4.7",
-        "os-name": "^2.0.1",
-        "update-notifier": "^1.0.2",
-        "string-length": "^1.0.1"
-    },
-    "devDependencies": {
-        "yeoman-assert": "^2.1.1",
-        "yeoman-test": "^1.0.0",
-        "gulp": "^3.9.1",
-        "gulp-babel": "^6.1.2",
-        "gulp-babel-istanbul": "^1.4.0",
-        "gulp-exclude-gitignore": "^1.0.0",
-        "gulp-jasmine": "2.4.0",
-        "gulp-jsdoc3": "^0.3.0",
-        "gulp-jshint": "2.0.1",
-        "gulp-plumber": "^1.0.0",
-        "gulp-nsp": "^2.1.0",
-        "gulp-coverage": "^0.3.38",
-        "gulp-spawn-mocha": "^3.1.0",
-        "istanbul": "0.4.5",
-        "jshint": "^2.9.3",
-        "jshint-stylish": "^2.1.0",
-        "merge-stream": "^1.0.0",
-        "mocha": "3.0.2",
-        "path": "^0.12.7",
-        "run-sequence": "^1.2.2"
-    },
-    "scripts": {
-        "prepublish": "gulp prepublish",
-        "test": "gulp"
-    },
-    "bugs": {
-        "url": "https://github.com/jmuelbert/generator-swift/issues"
-    },
-    "homepage": "https://github.com/jmuelbert/generator-swift#readme",
-    "directories": {
-        "test": "test"
-    },
-    "author": "Jürgen Mülbert"
+  "name": "generator-swift",
+  "version": "0.0.13",
+  "description": "Yeoman generator for opensource swift projects",
+  "license": "Apache-2.0",
+  "main": "app/index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jmuelbert/generator-swift.git"
+  },
+  "contributors": [
+    "Jürgen Mülbert < > (https://github.com/jmuelbert)"
+  ],
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "keywords": [
+    "yeoman-generator",
+    "swift"
+  ],
+  "files": [
+    "app"
+  ],
+  "dependencies": {
+    "chai": "^3.5.0",
+    "chalk": "^1.1.3",
+    "findup-sync": "^0.4.2",
+    "nconf": "^0.8.4",
+    "os-name": "^2.0.1",
+    "string-length": "^1.0.1",
+    "update-notifier": "^1.0.2",
+    "uuid": "^3.0.0",
+    "vs_projectname": "^1.0.2",
+    "yeoman-generator": "^0.22.5",
+    "yosay": "^1.1.0"
+  },
+  "devDependencies": {
+    "yeoman-assert": "^2.1.1",
+    "yeoman-test": "^1.0.0",
+    "gulp": "^3.9.1",
+    "gulp-babel": "^6.1.2",
+    "gulp-babel-istanbul": "^1.4.0",
+    "gulp-exclude-gitignore": "^1.0.0",
+    "gulp-jasmine": "2.4.0",
+    "gulp-jsdoc3": "^0.3.0",
+    "gulp-jshint": "2.0.1",
+    "gulp-plumber": "^1.0.0",
+    "gulp-nsp": "^2.1.0",
+    "gulp-coverage": "^0.3.38",
+    "gulp-spawn-mocha": "^3.1.0",
+    "istanbul": "0.4.5",
+    "jshint": "^2.9.3",
+    "jshint-stylish": "^2.1.0",
+    "merge-stream": "^1.0.0",
+    "mocha": "3.0.2",
+    "path": "^0.12.7",
+    "run-sequence": "^1.2.2"
+  },
+  "scripts": {
+    "prepublish": "gulp prepublish",
+    "test": "gulp"
+  },
+  "bugs": {
+    "url": "https://github.com/jmuelbert/generator-swift/issues"
+  },
+  "homepage": "https://github.com/jmuelbert/generator-swift#readme",
+  "directories": {
+    "test": "test"
+  },
+  "author": "Jürgen Mülbert"
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.